### PR TITLE
Detect rate limiting error in fb_ad_creative_retriever and exit when that happens

### DIFF
--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -438,6 +438,7 @@ class FacebookAdCreativeRetriever:
             error_text = self.chromedriver.find_element_by_xpath(SNAPSHOT_CONTENT_ROOT_XPATH).text
         except NoSuchElementException:
             page_text = self.chromedriver.find_element_by_tag_name('html').text
+            logging.warning('Could not find content in page:%s', page_text)
             if TOO_MANY_REQUESTS_ERROR_TEXT in page_text:
                 raise TooManyRequestsException
 

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -164,6 +164,7 @@ def chunks(original_list, chunk_size):
 def get_headless_chrome_driver(webdriver_executable_path):
     chrome_options = webdriver.ChromeOptions()
     chrome_options.add_argument("--headless")
+    chrome_options.add_argument("--disable-gpu")
     driver = webdriver.Chrome(executable_path=webdriver_executable_path,
                               chrome_options=chrome_options)
     return driver

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -640,7 +640,7 @@ class FacebookAdCreativeRetriever:
         self.db_interface.update_ad_snapshot_metadata(snapshot_metadata_records)
 
 
-def retrieve_and_store_ad_creatives(config, access_token, archive_ids, batch_size):
+def retrieve_and_store_ad_creatives(config, access_token, archive_ids, batch_size, slack_url):
     with get_database_connection(config) as db_connection:
         bucket_client = make_gcs_bucket_client(GCS_BUCKET, GCS_CREDENTIALS_FILE)
         image_retriever = FacebookAdCreativeRetriever(
@@ -675,9 +675,9 @@ def main(argv):
         exectutor_futures = []
         for archive_id_batch in chunks(archive_ids, DEFAULT_NUM_ARCHIVE_IDS_FOR_THREAD):
             new_future = executor.submit(
-                    retrieve_and_store_ad_creatives, config, access_token, archive_id_batch,
-                    batch_size, slack_url)
-            exectutor_futures.append(exectutor_futures)
+                retrieve_and_store_ad_creatives, config, access_token, archive_id_batch, batch_size,
+                slack_url)
+            exectutor_futures.append(new_future)
 
 
 if __name__ == '__main__':

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -542,6 +542,7 @@ class FacebookAdCreativeRetriever:
                 self.num_snapshots_fetch_failed += 1
                 # TODO(macpd): decide how to count the errors below
             except SnapshotNoContentFoundError as error:
+                logging.info('No content found for archive_id %d, %s', archive_id, snapshot_url)
                 snapshot_fetch_status = SnapshotFetchStatus.NO_CONTENT_FOUND
             except SnapshotAgeRestrictionError as error:
                 snapshot_fetch_status = SnapshotFetchStatus.AGE_RESTRICTION_ERROR

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -3,7 +3,6 @@ import concurrent.futures
 import configparser
 import datetime
 import enum
-import functools
 import hashlib
 import logging
 import io
@@ -208,7 +207,7 @@ def get_image_dhash(image_bytes):
 
 class FacebookAdCreativeRetriever:
 
-    def __init__(self, db_connection, bucket_client, access_token, batch_size):
+    def __init__(self, db_connection, bucket_client, access_token, batch_size, slack_url):
         self.bucket_client = bucket_client
         self.num_snapshots_processed = 0
         self.num_snapshots_fetch_failed = 0
@@ -222,6 +221,7 @@ class FacebookAdCreativeRetriever:
         self.access_token = access_token
         self.batch_size = batch_size
         self.start_time = None
+        self.slack_url = slack_url
         self.chromedriver = get_headless_chrome_driver(CHROMEDRIVER_PATH)
 
     def get_seconds_elapsed_procesing(self):
@@ -538,6 +538,15 @@ class FacebookAdCreativeRetriever:
                         'Unable to find ad creative(s) for archive_id: %s, snapshot_url: '
                         '%s', archive_id, snapshot_url)
 
+            except TooManyRequestsException as error:
+                # TODO(macpd): implement logic to signal all threads to backoff.
+                slack_notifier.notify_slack(self.slack_url,
+                        ':rotating_light: :rotating_light: :rotating_light: fb_ad_creative_retriever.py '
+                        'thread raised with TooManyRequestsException. Aborting! :rotating_light: '
+                        ':rotating_light: :rotating_light:')
+                logging.error('TooManyRequestsException raised aborting!')
+                sys.exit(1)
+
             except requests.RequestException as request_exception:
                 logging.info(
                     'Request exception while processing archive id:%s\n%s',
@@ -635,20 +644,9 @@ def retrieve_and_store_ad_creatives(config, access_token, archive_ids, batch_siz
     with get_database_connection(config) as db_connection:
         bucket_client = make_gcs_bucket_client(GCS_BUCKET, GCS_CREDENTIALS_FILE)
         image_retriever = FacebookAdCreativeRetriever(
-            db_connection, bucket_client, access_token, batch_size)
+            db_connection, bucket_client, access_token, batch_size, slack_url)
         image_retriever.retrieve_and_store_ad_creatives(archive_ids)
 
-def halt_if_too_many_requests_error(slack_url, invoking_thread_future):
-    thread_exception = invoking_thread_future.exception()
-    logging.info('Future %s finished with exception: %s %s', invoking_thread_future,
-                 type(thread_exception), thread_exception)
-    if isinstance(thread_exception, TooManyRequestsException):
-        slack_notifier.notify_slack(slack_url,
-                ':rotating_light: :rotating_light: :rotating_light: fb_ad_creative_retriever.py '
-                'thread terminated with TooManyRequestsException. Aborting! :rotating_light: '
-                ':rotating_light: :rotating_light:')
-        logging.error('Thread completed with TooManyRequestsException. Aborting!')
-        sys.exit(1)
 
 def main(argv):
     config = configparser.ConfigParser()
@@ -675,12 +673,10 @@ def main(argv):
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=max_threads) as executor:
         exectutor_futures = []
-        done_callback = functools.partial(halt_if_too_many_requests_error, slack_url)
         for archive_id_batch in chunks(archive_ids, DEFAULT_NUM_ARCHIVE_IDS_FOR_THREAD):
             new_future = executor.submit(
                     retrieve_and_store_ad_creatives, config, access_token, archive_id_batch,
-                    batch_size)
-            new_future.add_done_callback(done_callback)
+                    batch_size, slack_url)
             exectutor_futures.append(exectutor_futures)
 
 

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -436,7 +436,6 @@ class FacebookAdCreativeRetriever:
         try:
             error_text = self.chromedriver.find_element_by_xpath(SNAPSHOT_CONTENT_ROOT_XPATH).text
         except NoSuchElementException:
-            try:
             page_text = self.chromedriver.find_element_by_tag_name('html').text
             if TOO_MANY_REQUESTS_ERROR_TEXT in page_text:
                 raise TooManyRequestsException

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -642,7 +642,6 @@ def halt_if_too_many_requests_error(slack_url, invoking_thread_future):
     thread_exception = invoking_thread_future.exception()
     logging.info('Future %s finished with exception: %s %s', invoking_thread_future,
                  type(thread_exception), thread_exception)
-    #  if type(thread_exception)
     if isinstance(thread_exception, TooManyRequestsException):
         slack_notifier.notify_slack(slack_url,
                 ':rotating_light: :rotating_light: :rotating_light: fb_ad_creative_retriever.py '
@@ -683,7 +682,6 @@ def main(argv):
                     batch_size)
             new_future.add_done_callback(done_callback)
             exectutor_futures.append(exectutor_futures)
-        #concurrent.futures.wait(exectutor_futures, return_when=FIRST_EXCEPTION)
 
 
 if __name__ == '__main__':

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -642,7 +642,7 @@ def halt_if_too_many_requests_error(invoking_thread_future):
     #  if type(thread_exception)
     if isinstance(thread_exception, TooManyRequestsException):
         slack_url = config.get('LOGGING', 'SLACK_URL', fallback='')
-        slack_notifier.notify_slack(
+        slack_notifier.notify_slack(slack_url,
                 ':rotating_light: :rotating_light: :rotating_light: fb_ad_creative_retriever.py '
                 'thread completed with TooManyRequestsException. Aborting! :rotating_light: '
                 ':rotating_light: :rotating_light:')

--- a/fb_ad_creative_retriever.py
+++ b/fb_ad_creative_retriever.py
@@ -644,9 +644,9 @@ def halt_if_too_many_requests_error(slack_url, invoking_thread_future):
     if isinstance(thread_exception, TooManyRequestsException):
         slack_notifier.notify_slack(slack_url,
                 ':rotating_light: :rotating_light: :rotating_light: fb_ad_creative_retriever.py '
-                'thread completed with TooManyRequestsException. Aborting! :rotating_light: '
+                'thread terminated with TooManyRequestsException. Aborting! :rotating_light: '
                 ':rotating_light: :rotating_light:')
-        logging.error('Thread completed with TooManyRequestsException: %s. Aborting!')
+        logging.error('Thread completed with TooManyRequestsException. Aborting!')
         sys.exit(1)
 
 def main(argv):


### PR DESCRIPTION
This is initial implementation of logic prevent over doing ad creative retrieval. I hope to implement more sophisticated signalling of rate limit error to all threads so they can backoff. However, multiple threads on the same machine may not be the best approach for this problem.