### PR TITLE
change archive_id fetch batch schema and logic. do not use arrays

### DIFF
--- a/db_functions.py
+++ b/db_functions.py
@@ -445,7 +445,8 @@ class DBInterface():
         # COMMIT transaction to ensure no one else tries to take the same batch
         self.connection.commit()
 
-        archive_id_batch_query = 'SELECT archive_id FROM ad_snapshot_metadata WHERE batch_id = %s'
+        archive_id_batch_query = (
+                'SELECT archive_id FROM ad_snapshot_metadata WHERE snapshot_fetch_batch_id = %s')
         cursor.execute(archive_id_batch_query, (batch_id,))
         archive_ids_batch = [row['archive_id'] for row in cursor.fetchall()]
         # TODO(macpd): return this as a namedtuple

--- a/db_functions.py
+++ b/db_functions.py
@@ -401,7 +401,7 @@ class DBInterface():
             'ad_snapshot_metadata.needs_scrape = true AND '
             'ad_snapshot_metadata.snapshot_fetch_batch_id IS NULL ORDER BY ad_creation_time ASC')
         # This query inserts an empty row and gets back the autoincremented new batch_id.
-        new_batch_id_query = (
+        get_new_batch_id_query = (
             'INSERT INTO snapshot_fetch_batches (time_started, time_completed) VALUES (NULL, NULL) '
             'RETURNING batch_id')
         assign_batch_id_query = (
@@ -415,11 +415,11 @@ class DBInterface():
         fetched_rows = read_cursor.fetchmany()
         num_new_batches = 0
         while fetched_rows:
-            write_cursor.execute(new_batch_id_query)
-            new_batch_id = write_cursor.fetchone()['batch_id']
-            assign_batch_id_args = [(int(new_batch_id), int(row['archive_id'])) for row in fetched_rows]
+            write_cursor.execute(get_new_batch_id_query)
+            batch_id = write_cursor.fetchone()['batch_id']
+            assign_batch_id_args = [(int(batch_id), int(row['archive_id'])) for row in fetched_rows]
             logging.info(
-                'Assigning batch ID %d to %d archive IDs.', new_batch_id, len(assign_batch_id_args))
+                'Assigning batch ID %d to %d archive IDs.', batch_id, len(assign_batch_id_args))
             psycopg2.extras.execute_values(write_cursor,
                                            assign_batch_id_query,
                                            assign_batch_id_args,

--- a/db_functions.py
+++ b/db_functions.py
@@ -439,11 +439,11 @@ class DBInterface():
             'RETURNING batch_id')
         cursor.execute(claim_batch_for_fetch_query)
         row = cursor.fetchone()
+        # COMMIT transaction to ensure no one else tries to take the same batch
+        self.connection.commit()
         if not row:
             return None
         batch_id = row['batch_id']
-        # COMMIT transaction to ensure no one else tries to take the same batch
-        self.connection.commit()
 
         archive_id_batch_query = (
                 'SELECT archive_id FROM ad_snapshot_metadata WHERE snapshot_fetch_batch_id = %s')

--- a/db_functions.py
+++ b/db_functions.py
@@ -405,9 +405,10 @@ class DBInterface():
             'INSERT INTO snapshot_fetch_batches (time_started, time_completed) VALUES (NULL, NULL) '
             'RETURNING batch_id')
         assign_batch_id_query = (
-            'UPDATE ad_snapshot_metadata SET batch_id = data.batch_id FROM (VALUES %s) AS data '
-            '(batch_id, archive_id) WHERE ad_snapshot_metadata.archive_id = data.archive_id')
-        assign_batch_id_template = '(%(batch_id)s, %(archive_id)s)'
+            'UPDATE ad_snapshot_metadata SET snapshot_fetch_batch_id = data.batch_id FROM '
+            '(VALUES %s) AS data (batch_id, archive_id) WHERE '
+            'ad_snapshot_metadata.archive_id = data.archive_id')
+        assign_batch_id_template = '(%s, %s)'
         write_cursor = self.get_cursor()
         logging.info('Getting unfetched archive IDs.')
         read_cursor.execute(unbatched_archive_ids_query)
@@ -424,8 +425,8 @@ class DBInterface():
                                            assign_batch_id_args,
                                            template=assign_batch_id_template,
                                            page_size=batch_size)
-            print(write_cursor.query)
             num_new_batches += 1
+            fetched_rows = read_cursor.fetchmany()
 
         logging.info('Added %d new batches.', num_new_batches)
 

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -93,7 +93,7 @@ CREATE TABLE ad_snapshot_metadata (
   snapshot_fetch_batch_id bigint,
   PRIMARY KEY (archive_id),
   CONSTRAINT archive_id_fk FOREIGN KEY (archive_id) REFERENCES ads (archive_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
-  CONSTRAINT batch_id_fk FOREIGN KEY (snapshot_fetch_batch_id) REFERENCES snapshot_fetch_batches (batch_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+  CONSTRAINT batch_id_fk FOREIGN KEY (snapshot_fetch_batch_id) REFERENCES snapshot_fetch_batches (batch_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE SET NULL
 );
 CREATE TABLE ad_creatives (
   ad_creative_id bigserial PRIMARY KEY,

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -90,8 +90,10 @@ CREATE TABLE ad_snapshot_metadata (
   needs_scrape boolean DEFAULT TRUE,
   snapshot_fetch_time timestamp with timezone,
   snapshot_fetch_status int,
+  snapshot_fetch_batch_id bigint,
   PRIMARY KEY (archive_id),
-  CONSTRAINT archive_id_fk FOREIGN KEY (archive_id) REFERENCES ads (archive_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
+  CONSTRAINT archive_id_fk FOREIGN KEY (archive_id) REFERENCES ads (archive_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
+  CONSTRAINT batch_id_fk FOREIGN KEY (snapshot_fetch_batch_id) REFERENCES snapshot_fetch_batches (batch_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
 );
 CREATE TABLE ad_creatives (
   ad_creative_id bigserial PRIMARY KEY,
@@ -167,7 +169,6 @@ CREATE TABLE ad_clusters (
 );
 CREATE TABLE snapshot_fetch_batches (
   batch_id bigserial PRIMARY KEY,
-  archive_ids bigint[] NOT NULL,
   time_started timestamp with time zone,
   time_completed timestamp with time zone
 );


### PR DESCRIPTION
change archive_id fetch batch schema and logic. do not use arrays because they make existence checks hard or slow. instead add batch_id column to ad_snapshot_metadata table, and only track batch_id start and completion time in snapshot_fetch_batches.

