### PR TITLE
Better handle orphaned fetch batches (ie a task dies before completing a batch).

### DIFF
--- a/db_functions.py
+++ b/db_functions.py
@@ -489,7 +489,8 @@ class DBInterface():
         batch_id = row['batch_id']
 
         archive_id_batch_query = (
-                'SELECT archive_id FROM ad_snapshot_metadata WHERE snapshot_fetch_batch_id = %s')
+            'SELECT archive_id FROM ad_snapshot_metadata WHERE snapshot_fetch_batch_id = %s AND'
+            'needs_scrape = TRUE')
         cursor.execute(archive_id_batch_query, (batch_id,))
         archive_ids_batch = [row['archive_id'] for row in cursor.fetchall()]
         # TODO(macpd): return this as a namedtuple


### PR DESCRIPTION
* when fetching archive IDS to fetch from batch, only fetch those where needs_scrape == False

*  when getting snapshot_fetch_batches.batch_id chose from those not yet started or started more than 3 days ago. this is to handle batches orphaned from a fb_ad_creative task dying before finishing a batch or marking it complete.

